### PR TITLE
bring front title, make back img always cover & make maveli img respo…

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,9 @@
 	 background-image:url(hu.jpg);
    background-repeat:no-repeat;
    background-attachment: fixed;
-        background-size: 100%;
+   /* ensure image covers screen in vertical screens like on phone */
+        background-size: cover;
+		background-position: center;
 	 display: flex;
 	 justify-content: center;
 	 align-items: center;
@@ -36,6 +38,8 @@
 	 font-size: clamp(36px, 0.6rem, 100px);
 	 color: #fff;
 	 text-shadow: 6px 4px #735b13;
+	 /* ensure title is always above everything, specifically maveli image */
+	 z-index: 1;
 }
  [class^='firework-'] {
 	 position: absolute;
@@ -204,6 +208,13 @@
     text-align :left;
     position: absolute;
     left : 20px;
-    
+
       }
       </style>
+	<!-- make maveli image responsive to screen size -->
+	<script>
+		const body = document.querySelector('body');
+		const img = document.querySelector('img');
+		img.style.height = `${innerHeight * 0.95}px`;
+		body.onresize = () => img.style.height = `${innerHeight * 0.95}px`;
+	</script>


### PR DESCRIPTION
I made 3 simple changes to index.html
## bring front title
When you used to shrink the window before, the title would go behind the Maveli image and would disappear. I set the *z-index* to *1* so now when the image and title come to the same place after shrinking, the title is visible above Maveli.
## make back image always cover screen
Also when shrinking the screen to vertical screen, since the background image *hu.jpg* is landscape, it would only show in the top of the vertical screen leaving the bottom white. I set the body *background-size* to *cover* so that it covers the screen no matter what the screen size
## add script to change Maveli image size
Lastly I added some javascript so that Maveli image height is always 95% of screen height. I really would have preferred to use css for that but I couldn't find a way to do it without accessing built-in *innerHeight* variable in javascript.

I had fun working with this cute project. How you implemented the fireworks was really inspiring so thank you for teaching me that! And Happy Onam to you too :blush: